### PR TITLE
Implement Instagram-like notes carousel with pop-up

### DIFF
--- a/root/_data/notes.yml
+++ b/root/_data/notes.yml
@@ -1,0 +1,53 @@
+- title: CUDA Streams Basics
+  text: "A quick visual summary of CUDA streams, overlapping memcpy with kernel execution, and typical pitfalls."
+  images:
+    - https://picsum.photos/id/1015/800/800
+    - https://picsum.photos/id/1025/800/800
+    - https://picsum.photos/id/1039/800/800
+    - https://picsum.photos/id/1043/800/800
+    - https://picsum.photos/id/1050/800/800
+
+- title: Memory Coalescing Patterns
+  text: "Examples of coalesced vs. strided access, warp efficiency, and common alignment strategies."
+  images:
+    - https://picsum.photos/id/1074/800/800
+    - https://picsum.photos/id/1084/800/800
+    - https://picsum.photos/id/106/800/800
+    - https://picsum.photos/id/129/800/800
+    - https://picsum.photos/id/178/800/800
+
+- title: Shared Memory Tiling
+  text: "Tile-based matrix multiply diagrams, bank conflict avoidance, and occupancy tradeoffs."
+  images:
+    - https://picsum.photos/id/237/800/800
+    - https://picsum.photos/id/238/800/800
+    - https://picsum.photos/id/239/800/800
+    - https://picsum.photos/id/240/800/800
+    - https://picsum.photos/id/241/800/800
+
+- title: Warp Intrinsics Cheatsheet
+  text: "Ballot, shuffle, and reduction patterns illustrated with small code snippets and diagrams."
+  images:
+    - https://picsum.photos/id/242/800/800
+    - https://picsum.photos/id/243/800/800
+    - https://picsum.photos/id/244/800/800
+    - https://picsum.photos/id/245/800/800
+    - https://picsum.photos/id/246/800/800
+
+- title: Profiling Workflow
+  text: "Nsight Systems/Compute screenshots with annotations for identifying bottlenecks."
+  images:
+    - https://picsum.photos/id/247/800/800
+    - https://picsum.photos/id/248/800/800
+    - https://picsum.photos/id/249/800/800
+    - https://picsum.photos/id/250/800/800
+    - https://picsum.photos/id/251/800/800
+
+- title: Mixed Precision Tips
+  text: "Tensor cores, loss scaling, and numerical stability gotchas in FP16/TF32 workloads."
+  images:
+    - https://picsum.photos/id/252/800/800
+    - https://picsum.photos/id/253/800/800
+    - https://picsum.photos/id/254/800/800
+    - https://picsum.photos/id/255/800/800
+    - https://picsum.photos/id/256/800/800

--- a/root/_layouts/default.html
+++ b/root/_layouts/default.html
@@ -22,7 +22,7 @@ layout: compress
     </nav>
   </header>
 
-  <main>
+  <main class="container{% if page.wide %} container--wide{% endif %}">
     {{ content }}
   </main>
 

--- a/root/assets/css/style.css
+++ b/root/assets/css/style.css
@@ -1,14 +1,24 @@
 body {
   font-family: sans-serif;
-  max-width: 800px;
-  margin: auto;
+  margin: 0;
+  color: #111;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
   padding: 1rem;
+}
+
+.container--wide {
+  max-width: 1280px;
 }
 
 header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 1rem;
 }
 
 nav ul {
@@ -16,6 +26,7 @@ nav ul {
   padding: 0;
   display: flex;
   gap: 1rem;
+  margin: 0;
 }
 
 nav a {
@@ -25,4 +36,142 @@ nav a {
 
 nav a:hover {
   text-decoration: underline;
+}
+
+/* Notes grid */
+.notes-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+@media (max-width: 1024px) {
+  .notes-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .notes-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.notes-item {
+  position: relative;
+  background: #f8f8f8;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+/* Carousel (card) */
+.carousel {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  background: #ddd;
+}
+
+.carousel-track {
+  display: flex;
+  height: 100%;
+  width: 100%;
+  transition: transform 0.3s ease;
+}
+
+.carousel-slide {
+  min-width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.carousel-control {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  border: none;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.carousel:hover .carousel-control {
+  opacity: 1;
+}
+
+.carousel-control.prev { left: 8px; }
+.carousel-control.next { right: 8px; }
+
+/* Modal */
+.notes-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.notes-modal[aria-hidden="false"] {
+  display: flex;
+}
+
+.notes-modal__content {
+  background: white;
+  max-width: 1200px;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+@media (max-width: 900px) {
+  .notes-modal__content {
+    grid-template-columns: 1fr;
+  }
+}
+
+.notes-modal__media {
+  position: relative;
+  background: #000;
+}
+
+.notes-modal .carousel {
+  aspect-ratio: auto;
+  height: 70vh;
+  max-height: 80vh;
+}
+
+.notes-modal__sidebar {
+  padding: 16px;
+  overflow: auto;
+  max-height: 80vh;
+}
+
+.notes-modal__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  border: none;
+  border-radius: 18px;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
 }

--- a/root/assets/js/notes.js
+++ b/root/assets/js/notes.js
@@ -1,0 +1,123 @@
+(function () {
+  function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  function initCardCarousels() {
+    const carousels = document.querySelectorAll('.notes-grid .carousel');
+    carousels.forEach((carousel) => {
+      const track = carousel.querySelector('.carousel-track');
+      const slides = carousel.querySelectorAll('.carousel-slide');
+      const prev = carousel.querySelector('.carousel-control.prev');
+      const next = carousel.querySelector('.carousel-control.next');
+      let index = 0;
+
+      function update() {
+        const offset = -index * 100;
+        track.style.transform = `translateX(${offset}%)`;
+      }
+
+      prev?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        index = clamp(index - 1, 0, slides.length - 1);
+        update();
+      });
+
+      next?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        index = clamp(index + 1, 0, slides.length - 1);
+        update();
+      });
+
+      // Open modal when clicking anywhere on the carousel area (except buttons)
+      carousel.addEventListener('click', (e) => {
+        if ((e.target instanceof Element) && e.target.closest('.carousel-control')) return;
+        const imagesJson = carousel.getAttribute('data-images') || '[]';
+        const title = carousel.getAttribute('data-title') || '';
+        const text = carousel.getAttribute('data-text') || '';
+        let images = [];
+        try { images = JSON.parse(imagesJson); } catch {}
+        openModal({ images, title, text, startIndex: index });
+      });
+
+      update();
+    });
+  }
+
+  // Modal state
+  let modalIndex = 0;
+  let modalImages = [];
+
+  const modal = document.getElementById('notesModal');
+  const modalTrack = document.getElementById('modalCarouselTrack');
+  const modalPrev = document.getElementById('modalPrev');
+  const modalNext = document.getElementById('modalNext');
+  const modalClose = document.getElementById('modalClose');
+  const modalTitle = document.getElementById('modalTitle');
+  const modalText = document.getElementById('modalText');
+
+  function renderModalImages(images) {
+    modalTrack.innerHTML = '';
+    images.forEach((src, i) => {
+      const img = document.createElement('img');
+      img.className = 'carousel-slide';
+      img.src = src;
+      img.alt = `${modalTitle.textContent || 'image'} ${i + 1}`;
+      modalTrack.appendChild(img);
+    });
+  }
+
+  function updateModal() {
+    const offset = -modalIndex * 100;
+    modalTrack.style.transform = `translateX(${offset}%)`;
+  }
+
+  function openModal({ images, title, text, startIndex = 0 }) {
+    modalImages = images || [];
+    modalIndex = clamp(startIndex, 0, Math.max(0, modalImages.length - 1));
+    renderModalImages(modalImages);
+    modalTitle.textContent = title || '';
+    modalText.textContent = text || '';
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+    updateModal();
+  }
+
+  function closeModal() {
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+  }
+
+  modalPrev?.addEventListener('click', () => {
+    modalIndex = clamp(modalIndex - 1, 0, modalImages.length - 1);
+    updateModal();
+  });
+
+  modalNext?.addEventListener('click', () => {
+    modalIndex = clamp(modalIndex + 1, 0, modalImages.length - 1);
+    updateModal();
+  });
+
+  modalClose?.addEventListener('click', closeModal);
+
+  modal?.addEventListener('click', (e) => {
+    if (e.target === modal) closeModal();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (modal.getAttribute('aria-hidden') === 'true') return;
+    if (e.key === 'Escape') closeModal();
+    if (e.key === 'ArrowLeft') {
+      modalIndex = clamp(modalIndex - 1, 0, modalImages.length - 1);
+      updateModal();
+    }
+    if (e.key === 'ArrowRight') {
+      modalIndex = clamp(modalIndex + 1, 0, modalImages.length - 1);
+      updateModal();
+    }
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initCardCarousels();
+  });
+})();

--- a/root/notes.markdown
+++ b/root/notes.markdown
@@ -1,18 +1,47 @@
 ---
-layout: page
+layout: default
 title: Notes
 permalink: /notes/
+wide: true
 ---
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
+<div class="notes-grid">
+  {% assign notes = site.data.notes %}
+  {% if notes and notes.size > 0 %}
+    {% for note in notes %}
+      <div class="notes-item">
+        <div class="carousel" data-images='{{ note.images | jsonify | escape }}' data-title="{{ note.title | escape }}" data-text='{{ note.text | escape }}'>
+          <div class="carousel-track" style="width: calc(100% * {{ note.images | size }})">
+            {% for image in note.images %}
+              <img class="carousel-slide" src="{{ image }}" alt="{{ note.title | escape }} - {{ forloop.index }}" />
+            {% endfor %}
+          </div>
+          <button class="carousel-control prev" aria-label="Previous image">&#10094;</button>
+          <button class="carousel-control next" aria-label="Next image">&#10095;</button>
+        </div>
+      </div>
+    {% endfor %}
+  {% else %}
+    <p>No notes yet.</p>
+  {% endif %}
+</div>
 
-You can find the source code for Minima at GitHub:
-[jekyll][jekyll-organization] /
-[minima](https://github.com/jekyll/minima)
+<!-- Modal -->
+<div class="notes-modal" id="notesModal" aria-hidden="true" role="dialog" aria-modal="true">
+  <div class="notes-modal__content">
+    <div class="notes-modal__media">
+      <div class="carousel" id="modalCarousel">
+        <div class="carousel-track" id="modalCarouselTrack"></div>
+        <button class="carousel-control prev" id="modalPrev" aria-label="Previous image">&#10094;</button>
+        <button class="carousel-control next" id="modalNext" aria-label="Next image">&#10095;</button>
+      </div>
+      <button class="notes-modal__close" id="modalClose" aria-label="Close">&#10005;</button>
+    </div>
+    <aside class="notes-modal__sidebar">
+      <h2 id="modalTitle"></h2>
+      <div id="modalText"></div>
+    </aside>
+  </div>
+</div>
 
-You can find the source code for Jekyll at GitHub:
-[jekyll][jekyll-organization] /
-[jekyll](https://github.com/jekyll/jekyll)
-
-
-[jekyll-organization]: https://github.com/jekyll
+<script src="{{ '/assets/js/notes.js' | relative_url }}"></script>


### PR DESCRIPTION
Implement an Instagram-like layout for the Notes page with a 3-column grid, per-item carousels, and a full-size image modal, as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-70e4e337-2ab5-4543-9b65-ed5247d90155">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70e4e337-2ab5-4543-9b65-ed5247d90155">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

